### PR TITLE
Removed the Old Logo of HacktoberFest 2020

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # HacktoberFest
 ![HacktoberFest2021](https://user-images.githubusercontent.com/75477054/137994932-6beb2692-970f-4168-b8e5-e2b4bef0bc67.jpg)
 
-<! --- ## ![Hacktober Fest 2020](HacktoberFest.jpg) -->
 
 A repository to help budding developers have their first commit!
 


### PR DESCRIPTION
It appears so that the markdown comment did not work for **commenting** the old logo file line hence I have removed it completely so that repository looks beginner friendly _yet_ professional and more people come and contribute to it.

Now, the updated README.md should only display the logo of HacktoberFest 2021.